### PR TITLE
Fix jenkins 34102 add support for enviroment variable in main fields

### DIFF
--- a/src/main/java/jenkins/plugins/ssh2easy/gssh/GsshCommandBuilder.java
+++ b/src/main/java/jenkins/plugins/ssh2easy/gssh/GsshCommandBuilder.java
@@ -1,7 +1,9 @@
 package jenkins.plugins.ssh2easy.gssh;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -10,6 +12,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ListBoxModel;
 
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.logging.Logger;
 
@@ -21,7 +24,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * GSSH Builder extentation
- * 
+ *
  * @author Jerry Cai
  */
 public class GsshCommandBuilder extends Builder {
@@ -48,7 +51,7 @@ public class GsshCommandBuilder extends Builder {
 	@SuppressWarnings("rawtypes")
 	@Override
 	public boolean perform(AbstractBuild build, Launcher launcher,
-			BuildListener listener) {
+			BuildListener listener) throws IOException, InterruptedException {
 		PrintStream logger = listener.getLogger();
 		GsshBuilderWrapper.printSplit(logger);
 		if(isDisable()){
@@ -59,6 +62,9 @@ public class GsshCommandBuilder extends Builder {
 		// This is where you 'build' the project.
 		SshClient sshHandler = GsshBuilderWrapper.DESCRIPTOR.getSshClient(
 				getGroupName(), getIp());
+
+		EnvVars env = build.getEnvironment(listener);
+		String shell = Util.fixEmptyAndTrim(Util.replaceMacro(getShell(), env));
 		int exitStatus = sshHandler.executeCommand(logger, shell);
 		GsshBuilderWrapper.printSplit(logger);
 		return exitStatus == SshClient.STATUS_SUCCESS;
@@ -114,15 +120,18 @@ public class GsshCommandBuilder extends Builder {
 
 	@Extension
 	public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+		@Override
 		@SuppressWarnings("rawtypes")
 		public boolean isApplicable(Class<? extends AbstractProject> jobType) {
 			return true;
 		}
 
+		@Override
 		public String getDisplayName() {
 			return Messages.SSHCOMMAND_DisplayName();
 		}
 
+		@Override
 		public Builder newInstance(StaplerRequest req, JSONObject formData)
 				throws Descriptor.FormException {
 			return req.bindJSON(this.clazz, formData);

--- a/src/main/java/jenkins/plugins/ssh2easy/gssh/client/DefaultSshClient.java
+++ b/src/main/java/jenkins/plugins/ssh2easy/gssh/client/DefaultSshClient.java
@@ -20,14 +20,14 @@ import com.jcraft.jsch.UserInfo;
 
 /**
  * This is Ssh handler , user for handling SSH related event and requirments
- * 
+ *
  * @author Jerry Cai
- * 
+ *
  */
 public class DefaultSshClient extends AbstractSshClient {
 
 	public static final String SSH_BEY = "\nexit $?";
-	
+
 	private String ip;
 	private int port;
 	private String username;
@@ -86,6 +86,7 @@ public class DefaultSshClient extends AbstractSshClient {
 		return session;
 	}
 
+	@Override
 	public int uploadFile(PrintStream logger, String fileName,
 			InputStream fileContent, String serverLocation) {
 		Session session = null;
@@ -117,7 +118,9 @@ public class DefaultSshClient extends AbstractSshClient {
 			e.printStackTrace(logger);
 			throw new GsshPluginException(e);
 		} finally {
-			logger.println("[GSSH]-SFTP exit status is " + sftp.getExitStatus());
+			if (sftp != null) {
+				logger.println("[GSSH]-SFTP exit status is " + sftp.getExitStatus());
+			}
 			if (null != out) {
 				try {
 					out.close();
@@ -128,6 +131,7 @@ public class DefaultSshClient extends AbstractSshClient {
 		}
 	}
 
+	@Override
 	public int downloadFile(PrintStream logger, String remoteFile,
 			String localFolder, String fileName) {
 		Session session = null;
@@ -150,7 +154,9 @@ public class DefaultSshClient extends AbstractSshClient {
 			e.printStackTrace(logger);
 			throw new GsshPluginException(e);
 		} finally {
-			logger.println("[GSSH]-SFTP exit status is " + sftp.getExitStatus());
+			if (sftp != null) {
+				logger.println("[GSSH]-SFTP exit status is " + sftp.getExitStatus());
+			}
 			if (null != out) {
 				try {
 					out.close();
@@ -161,10 +167,12 @@ public class DefaultSshClient extends AbstractSshClient {
 		}
 	}
 
+	@Override
 	public int executeShell(PrintStream logger, String shell) {
 		return executeCommand(logger,shell);
 	}
 
+	@Override
 	public int executeCommand(PrintStream logger, String command) {
 
 		Session session = null;
@@ -222,6 +230,7 @@ public class DefaultSshClient extends AbstractSshClient {
 		}
 	}
 
+	@Override
 	public boolean testConnection(PrintStream logger) {
 		try {
 			Session session = createSession(logger);
@@ -249,13 +258,13 @@ public class DefaultSshClient extends AbstractSshClient {
 		String output = fixIEIssue(input);
 //		return SSH_PROFILE + output + SSH_BEY;
 		return output +SSH_BEY;
-//		return  output; 
+//		return  output;
 	}
 
 	/**
 	 * this is fix the IE issue that it's input shell /command auto add '<br>
 	 * ' if \n
-	 * 
+	 *
 	 * @param input
 	 * @return
 	 */
@@ -295,6 +304,7 @@ public class DefaultSshClient extends AbstractSshClient {
 		this.password = password;
 	}
 
+	@Override
 	public String toString() {
 		return "Server Info [" + this.ip + " ," + this.port + ","
 				+ this.username + "," + this.password + "]";

--- a/src/main/webapp/help-filepath.html
+++ b/src/main/webapp/help-filepath.html
@@ -1,1 +1,1 @@
-<div>the file path input here , like /var/temp/temp.sh  or C:/temp/config.properties  (windows)</div>
+<div>input here the file or folder path, like /var/temp/temp.sh, C:/temp/config.properties (windows) or C:/temp</div>


### PR DESCRIPTION
Add support for enviroment variable in some main fields.
New feature to support upload throw FTP of entire folder without know all single files name. The reason is that often we need to transfer local file that derive from SVC or artifact from other project that have in its name version of something like that make it impossible use FTP Upload action as is without support patterns (for example *.zip).
